### PR TITLE
Functions to adjust throughput

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "Set and reset DynamoDB provisioned throughput",
   "main": "index.js",
   "scripts": {
-    "pretest": "retire -p && jshint test index.js && jscs test index.js",
+    "pretest": "jshint test index.js && jscs test index.js",
     "test": "tape test/*.test.js"
   },
   "repository": {
@@ -23,7 +23,7 @@
   },
   "devDependencies": {
     "dynalite": "^0.9.0",
-    "jscs": "^1.11.3",
+    "jscs": "1.11.3",
     "jshint": "^2.6.3",
     "queue-async": "^1.0.7",
     "retire": "*",

--- a/readme.md
+++ b/readme.md
@@ -6,7 +6,7 @@ Set and reset provisioned DynamoDB throughput
 
 ## Usage
 
-You can set the table's read and write capacities to perform some operation that requires a lot of throughput. After you're done, you can reset the provisioned throughput to prior levels.
+You can set the table's read and write capacities to perform some operation that requires a lot of throughput. After you're done, you can reset the provisioned throughput to prior levels. If you change throughput multiple times, reseting will return to the original table values, before dynamodb-throughtput made any adjustments.
 
 ```js
 var throughput = require('dynamodb-throughput')('my-table', { region: 'us-east-1' });
@@ -29,6 +29,36 @@ var queue = require('queue-async');
 
 queue(1)
   .defer(throughput.setIndexCapacity, 'my-index', { read: 1000, write: 1000 })
+  .defer(doSomethingStrenuous)
+  .defer(throughput.resetIndexCapacity, 'my-index')
+  .awaitAll(function(err) {
+    console.log(err || 'All done!');
+  });
+```
+
+If you prefer, you can make adjustments to the table's existing throughput. For example, if you wanted to add 500 to the table's existing read capacity:
+
+```js
+var throughput = require('dynamodb-throughput')('my-table', { region: 'us-east-1' });
+var queue = require('queue-async');
+
+queue(1)
+  .defer(throughput.adjustCapacity, { read: 500 })
+  .defer(doSomethingStrenuous)
+  .defer(throughput.resetCapacity)
+  .awaitAll(function(err) {
+    console.log(err || 'All done!');
+  });
+```
+
+... and similarly for GlobalSecondaryIndexes:
+
+```js
+var throughput = require('dynamodb-throughput')('my-table', { region: 'us-east-1' });
+var queue = require('queue-async');
+
+queue(1)
+  .defer(throughput.setIndexCapacity, 'my-index', { read: 500 })
   .defer(doSomethingStrenuous)
   .defer(throughput.resetIndexCapacity, 'my-index')
   .awaitAll(function(err) {

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -191,6 +191,190 @@ test('dynamodb-throughput', function(assert) {
         next();
       });
     })
+    .defer(throughput.adjustCapacity, { read: 500, write: 400 })
+    .defer(function(next) {
+      dynamo.describeTable({
+        TableName: testTable.TableName
+      }, function(err, data) {
+        if (err) return next(err);
+
+        assert.equal(
+          data.Table.ProvisionedThroughput.ReadCapacityUnits,
+          501,
+          'adjusts main read capacity'
+        );
+
+        assert.equal(
+          data.Table.ProvisionedThroughput.WriteCapacityUnits,
+          401,
+          'adjusts main write capacity'
+        );
+
+        next();
+      });
+    })
+    .defer(throughput.resetCapacity)
+    .defer(function(next) {
+      dynamo.describeTable({
+        TableName: testTable.TableName
+      }, function(err, data) {
+        if (err) return next(err);
+
+        assert.equal(
+          data.Table.ProvisionedThroughput.ReadCapacityUnits,
+          1,
+          'resets main read capacity'
+        );
+
+        assert.equal(
+          data.Table.ProvisionedThroughput.WriteCapacityUnits,
+          1,
+          'resets main write capacity'
+        );
+
+        next();
+      });
+    })
+    .defer(throughput.adjustIndexCapacity, 'test-index', { read: 500, write: 400 })
+    .defer(function(next) {
+      dynamo.describeTable({
+        TableName: testTable.TableName
+      }, function(err, data) {
+        if (err) return next(err);
+
+        assert.equal(
+          data.Table.GlobalSecondaryIndexes[0].ProvisionedThroughput.ReadCapacityUnits,
+          501,
+          'sets index read capacity'
+        );
+
+        assert.equal(
+          data.Table.GlobalSecondaryIndexes[0].ProvisionedThroughput.WriteCapacityUnits,
+          401,
+          'sets index write capacity'
+        );
+
+        next();
+      });
+    })
+    .defer(throughput.resetIndexCapacity, 'test-index')
+    .defer(function(next) {
+      dynamo.describeTable({
+        TableName: testTable.TableName
+      }, function(err, data) {
+        if (err) return next(err);
+
+        assert.equal(
+          data.Table.GlobalSecondaryIndexes[0].ProvisionedThroughput.ReadCapacityUnits,
+          1,
+          'resets index read capacity'
+        );
+
+        assert.equal(
+          data.Table.GlobalSecondaryIndexes[0].ProvisionedThroughput.WriteCapacityUnits,
+          1,
+          'resets index write capacity'
+        );
+
+        next();
+      });
+    })
+    .defer(throughput.setCapacity, { read: 7, write: 8 })
+    .defer(throughput.setCapacity, { read: 12, write: 3 })
+    .defer(throughput.resetCapacity)
+    .defer(function(next) {
+      dynamo.describeTable({
+        TableName: testTable.TableName
+      }, function(err, data) {
+        if (err) return next(err);
+
+        assert.equal(
+          data.Table.ProvisionedThroughput.ReadCapacityUnits,
+          1,
+          'resets main read capacity to original value after multiple setCapacity calls'
+        );
+
+        assert.equal(
+          data.Table.ProvisionedThroughput.WriteCapacityUnits,
+          1,
+          'resets main write capacity to original value after multiple setCapacity calls'
+        );
+
+        next();
+      });
+    })
+    .defer(throughput.adjustCapacity, { read: 7, write: 8 })
+    .defer(throughput.adjustCapacity, { read: 12, write: 3 })
+    .defer(throughput.resetCapacity)
+    .defer(function(next) {
+      dynamo.describeTable({
+        TableName: testTable.TableName
+      }, function(err, data) {
+        if (err) return next(err);
+
+        assert.equal(
+          data.Table.ProvisionedThroughput.ReadCapacityUnits,
+          1,
+          'resets main read capacity to original value after multiple adjustCapacity calls'
+        );
+
+        assert.equal(
+          data.Table.ProvisionedThroughput.WriteCapacityUnits,
+          1,
+          'resets main write capacity to original value after multiple adjustCapacity calls'
+        );
+
+        next();
+      });
+    })
+    .defer(throughput.setIndexCapacity, 'test-index', { read: 7, write: 8 })
+    .defer(throughput.setIndexCapacity, 'test-index', { read: 12, write: 3 })
+    .defer(throughput.resetCapacity)
+    .defer(function(next) {
+      dynamo.describeTable({
+        TableName: testTable.TableName
+      }, function(err, data) {
+        if (err) return next(err);
+
+        assert.equal(
+          data.Table.ProvisionedThroughput.ReadCapacityUnits,
+          1,
+          'resets main read capacity to original value after multiple setIndexCapacity calls'
+        );
+
+        assert.equal(
+          data.Table.ProvisionedThroughput.WriteCapacityUnits,
+          1,
+          'resets main write capacity to original value after multiple setIndexCapacity calls'
+        );
+
+        next();
+      });
+    })
+    .defer(throughput.adjustIndexCapacity, 'test-index', { read: 7, write: 8 })
+    .defer(throughput.adjustIndexCapacity, 'test-index', { read: 12, write: 3 })
+    .defer(throughput.resetCapacity)
+    .defer(function(next) {
+      dynamo.describeTable({
+        TableName: testTable.TableName
+      }, function(err, data) {
+        if (err) return next(err);
+
+        assert.equal(
+          data.Table.ProvisionedThroughput.ReadCapacityUnits,
+          1,
+          'resets main read capacity to original value after multiple adjustIndexCapacity calls'
+        );
+
+        assert.equal(
+          data.Table.ProvisionedThroughput.WriteCapacityUnits,
+          1,
+          'resets main write capacity to original value after multiple adjustIndexCapacity calls'
+        );
+
+        next();
+      });
+    })
     .defer(dynamo.deleteTable.bind(dynamo), { TableName: testTable.TableName })
     .awaitAll(function(err) {
       if (err) throw err;
@@ -223,6 +407,50 @@ test('dynamodb-throughput (table without indexes)', function(assert) {
           data.Table.ProvisionedThroughput.WriteCapacityUnits,
           1000,
           'sets main write capacity'
+        );
+
+        next();
+      });
+    })
+    .defer(throughput.resetCapacity)
+    .defer(function(next) {
+      dynamo.describeTable({
+        TableName: testTable.TableName
+      }, function(err, data) {
+        if (err) return next(err);
+
+        assert.equal(
+          data.Table.ProvisionedThroughput.ReadCapacityUnits,
+          1,
+          'resets main read capacity'
+        );
+
+        assert.equal(
+          data.Table.ProvisionedThroughput.WriteCapacityUnits,
+          1,
+          'resets main write capacity'
+        );
+
+        next();
+      });
+    })
+    .defer(throughput.adjustCapacity, { read: 500, write: 400 })
+    .defer(function(next) {
+      dynamo.describeTable({
+        TableName: testTable.TableName
+      }, function(err, data) {
+        if (err) return next(err);
+
+        assert.equal(
+          data.Table.ProvisionedThroughput.ReadCapacityUnits,
+          501,
+          'adjusts main read capacity'
+        );
+
+        assert.equal(
+          data.Table.ProvisionedThroughput.WriteCapacityUnits,
+          401,
+          'adjusts main write capacity'
         );
 
         next();


### PR DESCRIPTION
Fixes #1, allows you to add/remove capacity from whatever the original value was, rather than just set the throughput to explicit values. Reset always returns to the original value, regardless of how many times throughput is adjusted.
