### PR TITLE
Add functions to provide information about throughput and partitioning

### DIFF
--- a/bin/dynamodb-throughput-adjustment.js
+++ b/bin/dynamodb-throughput-adjustment.js
@@ -1,0 +1,32 @@
+#!/usr/bin/env node
+
+var args = require('minimist')(process.argv.slice(2));
+var region = args._[0].split('/')[0];
+var table = args._[0].split('/')[1];
+var throughput = require('..')(table, { region: region });
+
+var adjustment = {};
+
+for (var key in args) {
+  if (key.split('-').length === 2) {
+    if (key.split('-')[0] === 'main') {
+      adjustment.main = adjustment.main || {};
+      adjustment.main[key.split('-')[1]] = Number(args[key]);
+    } else {
+      adjustment.indexes = adjustment.indexes || {};
+      adjustment.indexes[key.split('-')[0]] = {};
+      adjustment.indexes[key.split('-')[0]][key.split('-')[1]] = Number(args[key]);
+    }
+  }
+}
+
+throughput.adjustedTableInfo(adjustment, function(err, info, warnings) {
+  if (err) throw err;
+
+  if (warnings.main) console.error('WARNING: This adjustment would force the table to be repartitioned');
+  for (var index in warnings.indexes) {
+    console.error('WARNING: This adjustment would force the %s index to be repartitioned', index);
+  }
+
+  console.log(JSON.stringify(info, null, 2));
+});

--- a/bin/dynamodb-throughput-info.js
+++ b/bin/dynamodb-throughput-info.js
@@ -1,0 +1,10 @@
+#!/usr/bin/env node
+
+var region = process.argv[2].split('/')[0];
+var table = process.argv[2].split('/')[1];
+var throughput = require('..')(table, { region: region });
+
+throughput.tableInfo(function(err, info) {
+  if (err) throw err;
+  console.log(JSON.stringify(info, null, 2));
+});

--- a/package.json
+++ b/package.json
@@ -7,6 +7,10 @@
     "pretest": "jshint test index.js && jscs test index.js",
     "test": "tape test/*.test.js"
   },
+  "bin": {
+    "dynamodb-throughput-info": "bin/dynamodb-throughput-info.js",
+    "dynamodb-throughput-adjustment": "bin/dynamodb-throughput-adjustment.js"
+  },
   "repository": {
     "type": "git",
     "url": "https://github.com/mapbox/dynamodb-throughput.git"
@@ -19,15 +23,16 @@
   "author": "Mapbox",
   "license": "ISC",
   "dependencies": {
-    "aws-sdk": "^2.1.17"
+    "aws-sdk": "^2.1.17",
+    "minimist": "^1.1.1"
   },
   "devDependencies": {
-    "dynalite": "^0.9.0",
+    "dynalite": "^0.12.0",
     "jscs": "1.11.3",
     "jshint": "^2.6.3",
     "queue-async": "^1.0.7",
     "retire": "*",
-    "tape": "^3.5.0",
+    "tape": "^4.0.0",
     "underscore": "^1.8.2"
   },
   "jscsConfig": {

--- a/readme.md
+++ b/readme.md
@@ -6,6 +6,8 @@ Set and reset provisioned DynamoDB throughput
 
 ## Usage
 
+### Adjusting capacities
+
 You can set the table's read and write capacities to perform some operation that requires a lot of throughput. After you're done, you can reset the provisioned throughput to prior levels. If you change throughput multiple times, reseting will return to the original table values, before dynamodb-throughtput made any adjustments.
 
 ```js
@@ -67,3 +69,102 @@ queue(1)
 ```
 
 The second argument when creating the throughput object (`{ region: 'us-east-1' }` in these examples) is an options object passed to [`new AWS.DynamoDB(options)`](http://docs.aws.amazon.com/AWSJavaScriptSDK/latest/AWS/DynamoDB.html#constructor-property) to communicate with DynamoDB. Usually you should only need to provide a `region` property.
+
+### Getting throughput / partitioning information
+
+You can use this library to gather information about a table's current throughput and estimate its partitioning needs. See [the AWS DynamoDB documentation](http://docs.aws.amazon.com/amazondynamodb/latest/developerguide/GuidelinesForTables.html#GuidelinesForTables.Partitions) for more information about the way a table's partitioning needs are calculated.
+
+```js
+var throughput = require('dynamodb-throughput')('my-table', { region: 'us-east-1' });
+throughput.tableInfo(function(err, info) {
+  console.log(info);
+  // {
+  //   main: {
+  //     read: 4000,
+  //     write: 300,
+  //     size: 67432123,
+  //     partitions: 2
+  //   },
+  //   indexes: {
+  //     indexName: {
+  //       read: 300,
+  //       write: 100,
+  //       size: 873624,
+  //       partitions: 1
+  //     }
+  //   }
+  // }
+});
+```
+
+Increasing throughput can require your table to be repartitioned, and this can have unexpected consequences on the throughput performance of your table. This library can estimate the partitioning that would be required by a proposed throughput adjustment. Running this function has no impact on your table, it simply provides you with information about your table's state if you were to perform such an adjustment.
+
+```js
+var throughput = require('dynamodb-throughput')('my-table', { region: 'us-east-1' });
+var adjustment = { main: { read: 13000 } } // increases table's read capacity to 13000
+throughput.adjustedTableInfo(adjustment, function(err, info, warnings) {
+  console.log(info);
+  // {
+  //   main: {
+  //     read: 13000,
+  //     write: 300,
+  //     size: 67432123,
+  //     partitions: 5
+  //   },
+  //   indexes: {
+  //     indexName: {
+  //       read: 300,
+  //       write: 100,
+  //       size: 873624,
+  //       partitions: 1
+  //     }
+  //   }
+  // }
+  console.log(warnings);
+  // {
+  //   main: true,
+  //   indexes: {}
+  // }
+});
+```
+
+Included shell scripts can be used to run either of these functions.
+
+```sh
+$ npm install -g dynamodb-throughput
+$ dynamodb-throughput-info us-east-1/my-table
+# {
+#   main: {
+#     read: 4000,
+#     write: 300,
+#     size: 67432123,
+#     partitions: 2
+#   },
+#   indexes: {
+#     indexName: {
+#       read: 300,
+#       write: 100,
+#       size: 873624,
+#       partitions: 1
+#     }
+#   }
+# }
+$ dynamodb-throughput-adjustment us-east-1/my-table --main-read 13000
+# WARNING: This adjustment would force the table to be repartitioned
+# {
+#   main: {
+#     read: 13000,
+#     write: 300,
+#     size: 67432123,
+#     partitions: 5
+#   },
+#   indexes: {
+#     indexName: {
+#       read: 300,
+#       write: 100,
+#       size: 873624,
+#       partitions: 1
+#     }
+#   }
+# }
+```


### PR DESCRIPTION
Include some functionality that estimates your table's partitioning needs based on http://docs.aws.amazon.com/amazondynamodb/latest/developerguide/GuidelinesForTables.html#GuidelinesForTables.Partitions

Includes a function that can provide warnings if a proposed adjustment to throughput would require your table to be repartitioned.
