### PR TITLE
add partition counter based on stream shards

### DIFF
--- a/bin/dynamodb-partition-count.js
+++ b/bin/dynamodb-partition-count.js
@@ -1,0 +1,10 @@
+#!/usr/bin/env node
+
+var region = process.argv[2].split('/')[0];
+var table = process.argv[2].split('/')[1];
+var throughput = require('..')(table, { region: region });
+
+throughput.partitionCount(function(err, partitionCount) {
+  if (err) throw err;
+  console.log('Found %s partitions', partitionCount);
+});

--- a/package.json
+++ b/package.json
@@ -9,7 +9,8 @@
   },
   "bin": {
     "dynamodb-throughput-info": "bin/dynamodb-throughput-info.js",
-    "dynamodb-throughput-adjustment": "bin/dynamodb-throughput-adjustment.js"
+    "dynamodb-throughput-adjustment": "bin/dynamodb-throughput-adjustment.js",
+    "dynamodb-partition-count": "bin/dynamodb-partition-count.js"
   },
   "repository": {
     "type": "git",
@@ -23,8 +24,9 @@
   "author": "Mapbox",
   "license": "ISC",
   "dependencies": {
-    "aws-sdk": "^2.1.17",
-    "minimist": "^1.1.1"
+    "aws-sdk": "^2.1.46",
+    "minimist": "^1.1.1",
+    "queue-async": "^1.0.7"
   },
   "devDependencies": {
     "dynalite": "^0.12.0",


### PR DESCRIPTION
@mcwhittemore this script is an attempt to deduce dynamodb partition count by counting the number of active shards in the table's stream.
